### PR TITLE
cluster curator added to rbac aggregate

### DIFF
--- a/deploy/olm-catalog/multiclusterhub-operator/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multiclusterhub-operator/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -367,6 +367,7 @@ spec:
           - managedclusterviews/status
           - manifestworks
           - manifestworks/status
+          - clustercurators
           - clustermanagers
           - clusterroles
           - clusterrolebindings

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -281,6 +281,7 @@ rules:
   - managedclusterviews/status
   - manifestworks
   - manifestworks/status
+  - clustercurators
   - clustermanagers
   - clusterroles
   - clusterrolebindings

--- a/templates/multiclusterhub/base/rbac/clusterrole-admin-aggregate.yaml
+++ b/templates/multiclusterhub/base/rbac/clusterrole-admin-aggregate.yaml
@@ -9,7 +9,7 @@ metadata:
   name: open-cluster-management:admin-aggregate
 rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
-  resources: ["managedclusters", "managedclustersets", "managedclusters/status"]
+  resources: ["managedclusters", "managedclustersets", "managedclusters/status", "clustercurators"]
   verbs: ["get", "list", "watch", "update","delete", "deletecollection", "patch"]
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks", "manifestworks/status"]

--- a/templates/multiclusterhub/base/rbac/clusterrole-clustermanageradmin-aggregate.yaml
+++ b/templates/multiclusterhub/base/rbac/clusterrole-clustermanageradmin-aggregate.yaml
@@ -8,7 +8,7 @@ metadata:
   name: open-cluster-management:cluster-manager-admin-aggregate
 rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
-  resources: ["managedclusters", "managedclusters/accept","managedclusters/status"]
+  resources: ["managedclusters", "managedclusters/accept","managedclusters/status", "clustercurators"]
   verbs: ["create","get", "list", "watch", "update", "delete", "deletecollection", "patch"]
 - apiGroups: [""]
   resources: ["namespaces"]

--- a/templates/multiclusterhub/base/rbac/clusterrole-edit-aggregate.yaml
+++ b/templates/multiclusterhub/base/rbac/clusterrole-edit-aggregate.yaml
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: ["action.open-cluster-management.io"]
   resources: ["managedclusteractions", "managedclusteractions/status"]
-  verbs: ["get", "list", "watch", "update", "patch"]s
+  verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: ["view.open-cluster-management.io"]
   resources: ["managedclusterviews", "managedclusterviews/status"]
   verbs: ["get", "list", "watch", "update", "patch"]

--- a/templates/multiclusterhub/base/rbac/clusterrole-edit-aggregate.yaml
+++ b/templates/multiclusterhub/base/rbac/clusterrole-edit-aggregate.yaml
@@ -8,14 +8,14 @@ metadata:
   name: open-cluster-management:edit-aggregate
 rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
-  resources: ["managedclusters", "managedclustersets", "managedclusters/status"]
+  resources: ["managedclusters", "managedclustersets", "managedclusters/status", "clustercurators"]
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks", "manifestworks/status"]
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: ["action.open-cluster-management.io"]
   resources: ["managedclusteractions", "managedclusteractions/status"]
-  verbs: ["get", "list", "watch", "update", "patch"]
+  verbs: ["get", "list", "watch", "update", "patch"]s
 - apiGroups: ["view.open-cluster-management.io"]
   resources: ["managedclusterviews", "managedclusterviews/status"]
   verbs: ["get", "list", "watch", "update", "patch"]

--- a/templates/multiclusterhub/base/rbac/clusterrole-view-aggregate.yaml
+++ b/templates/multiclusterhub/base/rbac/clusterrole-view-aggregate.yaml
@@ -8,7 +8,7 @@ metadata:
   name: open-cluster-management:view-aggregate
 rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
-  resources: ["managedclusters", "managedclustersets", "managedclusters/status", "clustercurator"]
+  resources: ["managedclusters", "managedclustersets", "managedclusters/status", "clustercurators"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks", "manifestworks/status"]

--- a/templates/multiclusterhub/base/rbac/clusterrole-view-aggregate.yaml
+++ b/templates/multiclusterhub/base/rbac/clusterrole-view-aggregate.yaml
@@ -8,7 +8,7 @@ metadata:
   name: open-cluster-management:view-aggregate
 rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
-  resources: ["managedclusters", "managedclustersets", "managedclusters/status"]
+  resources: ["managedclusters", "managedclustersets", "managedclusters/status", "clustercurator"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks", "manifestworks/status"]


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Additions assume clustercurator rbac is equivalent to managedcluster rbac. 
clusterrole-foundation.yaml is an exception, as it isn't clear to me how the curator rbac should be defined in that context. Thus no changes to that yaml have been made in this PR (am looking for some guidance on how to approach that). 

If this is assumption about the curator's rbac is correct, I am hoping to get this PR approved. If not, the hope is to open up the discussion about how we should define it.