### PR TITLE
Validate deployment labels are updated

### DIFF
--- a/pkg/foundation/foundation.go
+++ b/pkg/foundation/foundation.go
@@ -56,6 +56,12 @@ func defaultLabels(app string) map[string]string {
 	}
 }
 
+func selectorLabels(app string) map[string]string {
+	return map[string]string{
+		"app": app,
+	}
+}
+
 func defaultTolerations() []corev1.Toleration {
 	return []corev1.Toleration{
 		{
@@ -119,6 +125,18 @@ func ValidateDeployment(m *operatorsv1.MultiClusterHub, overrides map[string]str
 		log.Info("Enforcing number of replicas")
 		replicas := getReplicaCount(m)
 		found.Spec.Replicas = &replicas
+		needsUpdate = true
+	}
+
+	// add missing labels to deployment
+	if utils.AddDeploymentLabels(found, expected.Labels) {
+		log.Info("Enforcing deployment labels")
+		needsUpdate = true
+	}
+
+	// add missing pod labels
+	if utils.AddPodLabels(found, expected.Spec.Template.Labels) {
+		log.Info("Enforcing pod labels")
 		needsUpdate = true
 	}
 

--- a/pkg/foundation/foundation_test.go
+++ b/pkg/foundation/foundation_test.go
@@ -61,6 +61,15 @@ func TestValidateDeployment(t *testing.T) {
 			},
 		},
 	}
+
+	// 9. Missing deployment labels
+	dep8 := dep.DeepCopy()
+	dep8.Labels = nil
+
+	// 10. Missing pod labels
+	dep9 := dep.DeepCopy()
+	dep9.Spec.Template.Labels = nil
+
 	type args struct {
 		m   *operatorsv1.MultiClusterHub
 		dep *appsv1.Deployment
@@ -116,6 +125,18 @@ func TestValidateDeployment(t *testing.T) {
 		{
 			name:  "Modified volumes",
 			args:  args{mch, dep7},
+			want:  dep,
+			want1: true,
+		},
+		{
+			name:  "Missing deployment labels",
+			args:  args{mch, dep8},
+			want:  dep,
+			want1: true,
+		},
+		{
+			name:  "Missing pod labels",
+			args:  args{mch, dep9},
 			want:  dep,
 			want1: true,
 		},

--- a/pkg/foundation/proxy_server.go
+++ b/pkg/foundation/proxy_server.go
@@ -138,7 +138,7 @@ func OCMProxyServerService(m *operatorsv1.MultiClusterHub) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: defaultLabels(OCMProxyServerName),
+			Selector: selectorLabels(OCMProxyServerName),
 			Ports: []corev1.ServicePort{{
 				Name:       "secure",
 				Protocol:   corev1.ProtocolTCP,

--- a/pkg/foundation/webhook.go
+++ b/pkg/foundation/webhook.go
@@ -115,7 +115,7 @@ func WebhookService(m *operatorsv1.MultiClusterHub) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: defaultLabels(WebhookName),
+			Selector: selectorLabels(WebhookName),
 			Ports: []corev1.ServicePort{{
 				Port:       443,
 				TargetPort: intstr.FromInt(8000),

--- a/pkg/helmrepo/helmrepo_test.go
+++ b/pkg/helmrepo/helmrepo_test.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package helmrepo
 
 import (
@@ -90,6 +89,14 @@ func TestValidateDeployment(t *testing.T) {
 	dep5 := dep.DeepCopy()
 	dep5.Spec.Template.Spec.Tolerations = nil
 
+	// 7. Missing deployment labels
+	dep6 := dep.DeepCopy()
+	dep6.Labels = selectorLabels()
+
+	// 8. Missing deployment labels
+	dep7 := dep.DeepCopy()
+	dep7.Spec.Template.Labels = selectorLabels()
+
 	type args struct {
 		m   *operatorsv1.MultiClusterHub
 		dep *appsv1.Deployment
@@ -133,6 +140,18 @@ func TestValidateDeployment(t *testing.T) {
 		{
 			name:  "Modified Tolerations",
 			args:  args{mch, dep5},
+			want:  dep,
+			want1: true,
+		},
+		{
+			name:  "Missing deployment labels",
+			args:  args{mch, dep6},
+			want:  dep,
+			want1: true,
+		},
+		{
+			name:  "Missing pod labels",
+			args:  args{mch, dep7},
 			want:  dep,
 			want1: true,
 		},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -96,6 +96,44 @@ func AddInstallerLabel(u *unstructured.Unstructured, name string, ns string) {
 	u.SetLabels(labels)
 }
 
+// addCustomLabels adds the labels to a deployment's labels, without removing existing ones.
+// Returns false if all the labels are already present.
+func AddDeploymentLabels(d *appsv1.Deployment, labels map[string]string) bool {
+	updated := false
+	if d.Labels == nil {
+		d.Labels = labels
+		return true
+	}
+
+	for k, v := range labels {
+		if d.Labels[k] != v {
+			d.Labels[k] = v
+			updated = true
+		}
+	}
+
+	return updated
+}
+
+// addCustomLabels adds the labels to a deployment's labels, without removing existing ones.
+// Returns false if all the labels are already present.
+func AddPodLabels(d *appsv1.Deployment, labels map[string]string) bool {
+	updated := false
+	if d.Spec.Template.Labels == nil {
+		d.Spec.Template.Labels = labels
+		return true
+	}
+
+	for k, v := range labels {
+		if d.Spec.Template.Labels[k] != v {
+			d.Spec.Template.Labels[k] = v
+			updated = true
+		}
+	}
+
+	return updated
+}
+
 // CoreToUnstructured converts a Core Kube resource to unstructured
 func CoreToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
 	content, err := json.Marshal(obj)


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/15356

The ocm-antiaffinity-selector label added in 2.2 is not properly applied
to deployments or their pod templates. In 2.3 the services were updated to
set this label in their selector while it is still missing from the pods. This
change will remove the antiaffinity label from the service selector and add it
to the pod template if it is missing.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>