### PR TITLE
Update channel annotation dynamically

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -249,7 +249,7 @@ func (r *MultiClusterHubReconciler) ensureChannel(m *operatorv1.MultiClusterHub,
 		return ctrl.Result{}, err
 	}
 
-	updated, needsUpdate := channel.Validate(found)
+	updated, needsUpdate := channel.Validate(m, found)
 	if needsUpdate {
 		selog.Info("Updating channel")
 		err = r.Client.Update(context.TODO(), updated)


### PR DESCRIPTION
While the mch is installing or upgrading the appsub reconcile rate will
be set to high. Once the desired version has been reached it will be
set to low.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>