### PR TITLE
Update channel annotation dynamically (2.3)

### DIFF
--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -6,6 +6,7 @@ package channel
 import (
 	"fmt"
 
+	"github.com/open-cluster-management/multiclusterhub-operator/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -21,8 +22,13 @@ var ChannelName = "charts-v1"
 var Schema = schema.GroupVersionResource{Group: "apps.open-cluster-management.io", Version: "v1", Resource: "channels"}
 
 // custom annotation to reduce reconcilation rate to once per hour (default is 15 minutes)
-var Annotation = map[string]string{
+var AnnotationRateLow = map[string]string{
 	"apps.open-cluster-management.io/reconcile-rate": "low",
+}
+
+// custom annotation to increase reconcilation rate to once every two minutes (default is 15 minutes)
+var AnnotationRateHigh = map[string]string{
+	"apps.open-cluster-management.io/reconcile-rate": "high",
 }
 
 // build Helm pathname from repo name and por
@@ -46,7 +52,12 @@ func Channel(m *operatorsv1.MultiClusterHub) *unstructured.Unstructured {
 			},
 		},
 	}
-	ch.SetAnnotations(Annotation)
+	if m.Status.CurrentVersion != version.Version {
+		ch.SetAnnotations(AnnotationRateHigh)
+	} else {
+		ch.SetAnnotations(AnnotationRateLow)
+	}
+
 	ch.SetOwnerReferences([]metav1.OwnerReference{
 		*metav1.NewControllerRef(m, m.GetObjectKind().GroupVersionKind()),
 	})
@@ -55,31 +66,47 @@ func Channel(m *operatorsv1.MultiClusterHub) *unstructured.Unstructured {
 
 // Validate returns true if an update is needed to reconcile differences with the current spec. If an update
 // is needed it returns the object with the new spec to update with.
-func Validate(found *unstructured.Unstructured) (*unstructured.Unstructured, bool) {
+func Validate(m *operatorsv1.MultiClusterHub, found *unstructured.Unstructured) (*unstructured.Unstructured, bool) {
 	updateNeeded := false
 
 	// Verify reconcile-rate annotation is set
-	if checkAnnotation(found) == false {
-		setAnnotation(found)
+	if annotationsCorrect(m, found) == false {
+		setAnnotation(m, found)
 		updateNeeded = true
 	}
 	return found, updateNeeded
 }
 
-func checkAnnotation(u *unstructured.Unstructured) bool {
+func annotationsCorrect(m *operatorsv1.MultiClusterHub, u *unstructured.Unstructured) bool {
 	a := u.GetAnnotations()
-	if a == nil || a["apps.open-cluster-management.io/reconcile-rate"] != "low" {
+	if a == nil || a["apps.open-cluster-management.io/reconcile-rate"] != desiredRate(m) {
 		return false
 	}
 	return true
 }
 
-func setAnnotation(u *unstructured.Unstructured) {
+func setAnnotation(m *operatorsv1.MultiClusterHub, u *unstructured.Unstructured) {
 	a := u.GetAnnotations()
 	if a == nil {
-		u.SetAnnotations(Annotation)
+		u.SetAnnotations(desiredAnnotation(m))
 	} else {
-		a["apps.open-cluster-management.io/reconcile-rate"] = "low"
+		a["apps.open-cluster-management.io/reconcile-rate"] = desiredRate(m)
 		u.SetAnnotations(a)
+	}
+}
+
+func desiredAnnotation(m *operatorsv1.MultiClusterHub) map[string]string {
+	if m.Status.CurrentVersion != version.Version {
+		return AnnotationRateHigh
+	} else {
+		return AnnotationRateLow
+	}
+}
+
+func desiredRate(m *operatorsv1.MultiClusterHub) string {
+	if m.Status.CurrentVersion != version.Version {
+		return "high"
+	} else {
+		return "low"
 	}
 }

--- a/pkg/controller/multiclusterhub/common.go
+++ b/pkg/controller/multiclusterhub/common.go
@@ -251,7 +251,7 @@ func (r *ReconcileMultiClusterHub) ensureChannel(m *operatorsv1.MultiClusterHub,
 		return &reconcile.Result{}, err
 	}
 
-	updated, needsUpdate := channel.Validate(found)
+	updated, needsUpdate := channel.Validate(m, found)
 	if needsUpdate {
 		selog.Info("Updating channel")
 		err = r.client.Update(context.TODO(), updated)


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/15991

While the mch is installing or upgrading the appsub reconcile rate will
be set to high. Once the desired version has been reached it will be
set to low.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>